### PR TITLE
0.3.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,6 @@ updates:
     directory: "/proxy-lib"
     schedule:
       interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/legacy"
-    schedule:
-      interval: "daily"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 You should also include the user name that made the change.
 -->
 
+## 0.4 (Unreleased)
+
 ## 0.3.2
 
 ### Improvements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
 
 members = ["proxy-bin", "proxy-lib"]
-exclude = ["legacy"]
 resolver = "2"
 
 [profile.release]

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,7 +19,7 @@ Other than them, we have the following environment variables as `doh-auth-proxy`
 # TARGET_URLS=https://dns.google/dns-query
 TARGET_URLS=https://odoh.cloudflare-dns.com/dns-query
 TARGET_RANDOMIZATION=true
-BOOTSTRAP_DNS_ADDR=1.1.1.1
+BOOTSTRAP_DNS=1.1.1.1
 # URL-like specification is also supported.
 # BOOTSTRAP_DNS=tcp://1.1.1.1:53
 


### PR DESCRIPTION
- Feat: Support TCP and UDP bootstrap DNS protocols. In addition to the existing format like "1.1.1.1" that means "udp://1.1.1.1:53", formats like "tcp://1.1.1.1:53" (TCP support) "udp://1.2.3.4:50053" (Non standard port) works. See "README.md" and "doh-auth-proxy.toml" for configuration for the detail.
- Refactor: Lots of minor improvements