### PR TITLE
Feat/not forwarded arpa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@
 You should also include the user name that made the change.
 -->
 
-## 0.4.0 (Unreleased)
+## 0.4.2 (Unreleased)
+
+## 0.4.1
+
+- Feat: support handling not-forwarded domains and local domains by default. For example, `resolver.arpa` is not forwarded to the upstream resolver, and `localhost` is always resolved to `127.0.0.1` or `::1`.
+- Refactor: Various minor improvements
+- Deps.
+
+## 0.4.0
 
 - Feat: Support anonymous token based on blind RSA signatures.
 - Feat: DNS query logging (`qrlog` feature)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["proxy-bin", "proxy-lib"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Jun Kurihara"]
 homepage = "https://github.com/junkurihara/doh-auth-proxy"
 repository = "https://github.com/junkurihara/doh-auth-proxy"

--- a/proxy-lib/src/constants.rs
+++ b/proxy-lib/src/constants.rs
@@ -96,6 +96,10 @@ pub const HEALTHCHECK_TARGET_ADDR: &str = "8.8.8.8";
 pub const BLOCK_MESSAGE_HINFO_CPU: &str = "BLOCKED";
 /// Block message for query manipulation (HINFO OS field)
 pub const BLOCK_MESSAGE_HINFO_OS: &str = "POWERED-BY-DOH-AUTH-PROXY";
+/// Not-forwarded message for query manipulation (HINFO CPU field)
+pub const NOT_FORWARDED_MESSAGE_HINFO_CPU: &str = "NOT-FORWARDED-BY-DEFAULT";
+/// Not-forwarded message for query manipulation (HINFO OS field)
+pub const NOT_FORWARDED_MESSAGE_HINFO_OS: &str = "POWERED-BY-DOH-AUTH-PROXY";
 
 // Logging
 /// Query log channel size

--- a/proxy-lib/src/doh_client/dns_message.rs
+++ b/proxy-lib/src/doh_client/dns_message.rs
@@ -120,6 +120,14 @@ pub fn build_response_nx(msg: &Message) -> Message {
   res
 }
 
+/// Build a DNS response message with REFUSED
+pub fn build_response_refused(msg: &Message) -> Message {
+  let mut res = msg.clone();
+  res.set_message_type(hickory_proto::op::MessageType::Response);
+  res.set_response_code(hickory_proto::op::ResponseCode::Refused);
+  res
+}
+
 /// Build a DNS response message for given QueryKey and IP address
 pub fn build_response_given_ipaddr(msg: &Message, q_key: &QueryKey, ipaddr: &IpAddr, min_ttl: u32) -> anyhow::Result<Message> {
   let mut res = msg.clone();

--- a/proxy-lib/src/doh_client/manipulation/default_rule.rs
+++ b/proxy-lib/src/doh_client/manipulation/default_rule.rs
@@ -1,0 +1,159 @@
+use super::{
+  super::{
+    dns_message::{build_response_given_ipaddr, build_response_refused, QueryKey},
+    error::DohClientError,
+  },
+  inspect_query_name, QueryManipulation, QueryManipulationResult,
+};
+use crate::{
+  constants::{NOT_FORWARDED_MESSAGE_HINFO_CPU, NOT_FORWARDED_MESSAGE_HINFO_OS},
+  log::*,
+};
+use async_trait::async_trait;
+use hickory_proto::{op::Message, rr};
+use match_domain::DomainMatchingRule;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/* -------------------------------------------------------- */
+/// Default not-forwarded domains
+const DEFAULT_NOT_FORWARDED_DOMAINS: &[&str] = &[
+  // https://www.rfc-editor.org/rfc/rfc9462.html#name-caching-forwarders
+  "resolver.arpa",
+];
+/// Default localhost
+const DEFAULT_LOCAL_DOMAINS: &[&str] = &["localhost", "localhost.localdomain"];
+/// Default broadcast
+const DEFAULT_BROADCAST_DOMAINS: &[&str] = &["broadcasthost"];
+
+#[inline]
+fn build_local_v4_response(query_message: &Message, query_key: &QueryKey) -> anyhow::Result<Message> {
+  let addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+  build_response_given_ipaddr(query_message, query_key, &addr, 0)
+}
+#[inline]
+fn build_local_v6_response(query_message: &Message, query_key: &QueryKey) -> anyhow::Result<Message> {
+  let addr = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+  build_response_given_ipaddr(query_message, query_key, &addr, 0)
+}
+#[inline]
+// only v4
+fn build_broadcast_response(query_message: &Message, query_key: &QueryKey) -> anyhow::Result<Message> {
+  let addr = IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255));
+  build_response_given_ipaddr(query_message, query_key, &addr, 0)
+}
+/* -------------------------------------------------------- */
+
+#[async_trait]
+impl QueryManipulation for DefaultRule {
+  type Error = DohClientError;
+
+  /// Apply query plugin
+  async fn apply(&self, query_message: &Message, query_key: &QueryKey) -> Result<QueryManipulationResult, DohClientError> {
+    let q_name = inspect_query_name(&query_key.query_name)?;
+
+    // Check if the query is for not-forwarded domains
+    if self.is_not_forwarded(q_name.as_str())? {
+      debug!(
+        "[Not-Forwarded] {} {:?} {:?}",
+        query_key.query_name, query_key.query_type, query_key.query_class
+      );
+      let response_msg = build_response_not_forwarded(query_message);
+      return Ok(QueryManipulationResult::SyntheticResponseNotForwarded(response_msg));
+    }
+
+    // Check if the query is for localhost
+    if self.is_localhost(q_name.as_str()) {
+      debug!(
+        "[LocalHost] {} {:?} {:?}",
+        query_key.query_name, query_key.query_type, query_key.query_class
+      );
+
+      let response_msg = match query_key.query_type {
+        rr::RecordType::A => build_local_v4_response(query_message, query_key)?,
+        rr::RecordType::AAAA => build_local_v6_response(query_message, query_key)?,
+        _ => build_response_refused(query_message),
+      };
+      return Ok(QueryManipulationResult::SyntheticResponseDefaultHost(response_msg));
+    }
+
+    // Check if the query is for broadcast
+    if self.is_broadcast(q_name.as_str()) {
+      debug!(
+        "[Broadcast] {} {:?} {:?}",
+        query_key.query_name, query_key.query_type, query_key.query_class
+      );
+
+      let response_msg = match query_key.query_type {
+        rr::RecordType::A => build_broadcast_response(query_message, query_key)?,
+        _ => build_response_refused(query_message),
+      };
+      return Ok(QueryManipulationResult::SyntheticResponseDefaultHost(response_msg));
+    }
+
+    return Ok(QueryManipulationResult::PassThrough);
+  }
+}
+
+/// Build a synthetic response message for default not-forwarded domains
+fn build_response_not_forwarded(query_message: &Message) -> Message {
+  let mut msg = build_response_refused(query_message);
+  let hinfo = rr::rdata::HINFO::new(
+    NOT_FORWARDED_MESSAGE_HINFO_CPU.to_string(),
+    NOT_FORWARDED_MESSAGE_HINFO_OS.to_string(),
+  );
+  msg.add_answer(rr::Record::from_rdata(
+    query_message.queries()[0].name().clone(),
+    0,
+    rr::RData::HINFO(hinfo),
+  ));
+  msg
+}
+
+#[derive(Debug, Clone)]
+/// NotForwardedRule is a query manipulation rule that refuses queries based on domain matching
+/// This is a default rule, handling the regulations of IETF RFC
+pub struct DefaultRule {
+  /// inner domain matching rule
+  not_forwarded: DomainMatchingRule,
+}
+
+impl DefaultRule {
+  /// Create a new NotForwardedRule
+  pub fn new() -> Self {
+    let not_forwarded = DomainMatchingRule::try_from(DEFAULT_NOT_FORWARDED_DOMAINS).unwrap();
+    DefaultRule { not_forwarded }
+  }
+
+  /// Check if the query key is in blocklist
+  fn is_not_forwarded(&self, q_name: &str) -> anyhow::Result<bool> {
+    Ok(self.not_forwarded.is_matched(q_name))
+  }
+
+  /// Check if the query key is for localhost
+  fn is_localhost(&self, q_name: &str) -> bool {
+    DEFAULT_LOCAL_DOMAINS.iter().any(|&d| d.eq(q_name))
+  }
+  /// Check if the query key is for broadcast
+  fn is_broadcast(&self, q_name: &str) -> bool {
+    DEFAULT_BROADCAST_DOMAINS.iter().any(|&d| d.eq(q_name))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn default_works() {
+    let default_rule = DefaultRule::new();
+
+    assert!(default_rule.is_not_forwarded("resolver.arpa").unwrap());
+    assert!(default_rule.is_not_forwarded("_dns.resolver.arpa").unwrap());
+    assert!(default_rule.is_localhost("localhost"));
+    assert!(default_rule.is_localhost("localhost.localdomain"));
+    assert!(!default_rule.is_localhost("localhost.localdomain.com"));
+    assert!(!default_rule.is_localhost("x.localhost.localdomain"));
+    assert!(default_rule.is_broadcast("broadcasthost"));
+    assert!(!default_rule.is_broadcast("broadcasthost.com"));
+  }
+}

--- a/proxy-lib/src/doh_client/mod.rs
+++ b/proxy-lib/src/doh_client/mod.rs
@@ -18,6 +18,10 @@ pub enum DoHResponseType {
   Blocked,
   /// Overridden response
   Overridden,
+  /// Not forwarded due to the nature of dns forwarding (like resolver.arpa)
+  NotForwarded,
+  /// Overridden response for the localhost and broadcast addresses
+  DefaultHost,
   /// Cached response
   Cached,
   /// Standard response fetched from upstream
@@ -29,6 +33,8 @@ impl std::fmt::Display for DoHResponseType {
     match self {
       DoHResponseType::Blocked => write!(f, "Blocked"),
       DoHResponseType::Overridden => write!(f, "Overridden"),
+      DoHResponseType::NotForwarded => write!(f, "NotForwarded"),
+      DoHResponseType::DefaultHost => write!(f, "DefaultHost"),
       DoHResponseType::Cached => write!(f, "Cached"),
       DoHResponseType::Normal => write!(f, "Normal"),
     }

--- a/proxy-lib/src/log.rs
+++ b/proxy-lib/src/log.rs
@@ -70,6 +70,8 @@ impl QueryLoggingBase {
     let dst = match self.res_type {
       DoHResponseType::Blocked => "blocked".to_owned(),
       DoHResponseType::Overridden => "overridden".to_owned(),
+      DoHResponseType::NotForwarded => "not_forwarded".to_owned(),
+      DoHResponseType::DefaultHost => "default_host".to_owned(),
       DoHResponseType::Cached => "cached".to_owned(),
       DoHResponseType::Normal => {
         if let Some(dst_url) = &self.dst_url {


### PR DESCRIPTION
- Feat: support handling not-forwarded domains and local domains by default. For example, `resolver.arpa` is not forwarded to the upstream resolver, and `localhost` is always resolved to `127.0.0.1` or `::1`.
- Refactor: Various minor improvements
- Deps.