### PR TITLE
0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@
 You should also include the user name that made the change.
 -->
 
-## 0.4.2 (Unreleased)
+## 0.4.3 (Unreleased)
+
+## 0.4.2
+
+- Feat: Change the default hasher for hashmaps and hashsets from `FxHash` to `aHash` for better performance with string keys. Use `ArcSwap` instead of `RwLock` for internal ODoH config storage.
+- Deps.
+- Refactor: Various minor improvements.
 
 ## 0.4.1
 

--- a/proxy-bin/Cargo.toml
+++ b/proxy-bin/Cargo.toml
@@ -19,9 +19,9 @@ doh-auth-proxy-lib = { path = "../proxy-lib/", default-features = false, feature
   "anonymous-token",
 ] }
 
-anyhow = "1.0.94"
+anyhow = "1.0.95"
 mimalloc = { version = "*", default-features = false }
-serde = { version = "1.0.216", default-features = false, features = ["derive"] }
+serde = { version = "1.0.217", default-features = false, features = ["derive"] }
 derive_builder = "0.20.2"
 tokio = { version = "1.42.0", default-features = false, features = [
   "net",
@@ -30,7 +30,7 @@ tokio = { version = "1.42.0", default-features = false, features = [
   "sync",
   "macros",
 ] }
-async-trait = "0.1.83"
+async-trait = "0.1.84"
 
 # config
 clap = { version = "4.5.23", features = ["std", "cargo", "wrap_help"] }

--- a/proxy-lib/Cargo.toml
+++ b/proxy-lib/Cargo.toml
@@ -33,9 +33,12 @@ tracing = "0.1.41"
 thiserror = "2.0.9"
 async-trait = "0.1.84"
 serde = { version = "1.0.217", features = ["derive"] }
-itertools = "0.13.0"
-rustc-hash = "2.1.0"
+itertools = "0.14.0"
+ahash = "0.8.11"
 crossbeam-channel = "0.5.14"
+
+# odoh config server
+arc-swap = "1.7.1"
 
 # doh and odoh client with cache and query manipulation plugins
 odoh-rs = { git = "https://github.com/junkurihara/odoh-rs.git", branch = "master" }

--- a/proxy-lib/Cargo.toml
+++ b/proxy-lib/Cargo.toml
@@ -28,11 +28,11 @@ futures = { version = "0.3.31", default-features = false, features = [
   "std",
   "async-await",
 ] }
-anyhow = "1.0.94"
+anyhow = "1.0.95"
 tracing = "0.1.41"
-thiserror = "2.0.8"
-async-trait = "0.1.83"
-serde = { version = "1.0.216", features = ["derive"] }
+thiserror = "2.0.9"
+async-trait = "0.1.84"
+serde = { version = "1.0.217", features = ["derive"] }
 itertools = "0.13.0"
 rustc-hash = "2.1.0"
 crossbeam-channel = "0.5.14"
@@ -50,7 +50,7 @@ regex = "1.11.1"
 socket2 = "0.5.8"
 
 # http client
-reqwest = { version = "0.12.9", default-features = false, features = [
+reqwest = { version = "0.12.12", default-features = false, features = [
   "json",
   "http2",
   "hickory-dns",

--- a/proxy-lib/src/doh_client/cache.rs
+++ b/proxy-lib/src/doh_client/cache.rs
@@ -1,12 +1,15 @@
 use super::dns_message::{self, Request};
 use crate::log::*;
 use anyhow::anyhow;
-use hashlink::{linked_hash_map::RawEntryMut, LinkedHashMap};
+use hashlink::linked_hash_map::RawEntryMut;
 use hickory_proto::op::Message;
 use tokio::{
   sync::Mutex,
   time::{Duration, Instant},
 };
+
+/// Type alias for LinkedHashMap using ahash::RandomState as hasher
+type LinkedHashMap<K, V> = hashlink::LinkedHashMap<K, V, ahash::RandomState>;
 
 #[derive(Debug, Clone)]
 /// Cache object
@@ -75,7 +78,7 @@ impl Cache {
   /// Create a new cache
   pub fn new(max_size: usize) -> Self {
     Cache {
-      cache: Mutex::new(LinkedHashMap::new()),
+      cache: Mutex::new(LinkedHashMap::default()),
       max_size,
     }
   }

--- a/proxy-lib/src/doh_client/doh_client_main.rs
+++ b/proxy-lib/src/doh_client/doh_client_main.rs
@@ -325,9 +325,6 @@ impl DoHClient {
     let Some(odoh_config) = self.odoh_configs.as_ref().unwrap().get(target_obj).await else {
       return Err(DohClientError::ODoHNoClientConfig);
     };
-    let Some(odoh_config) = odoh_config.as_ref() else {
-      return Err(DohClientError::ODoHNoClientConfig);
-    };
 
     // encrypt query
     let (odoh_plaintext_query, encrypted_query_body, secret) = odoh_config.encrypt_query(packet_buf)?;

--- a/proxy-lib/src/doh_client/manipulation/domain_override.rs
+++ b/proxy-lib/src/doh_client/manipulation/domain_override.rs
@@ -8,10 +8,10 @@ use super::{
   QueryManipulation, QueryManipulationResult,
 };
 use crate::{log::*, QueryManipulationConfig};
+use ahash::HashMap;
 use async_trait::async_trait;
 use hickory_proto::{op::Message, rr};
 use regex::Regex;
-use rustc_hash::FxHashMap as HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 #[async_trait]


### PR DESCRIPTION
## 0.4.2

- Feat: Change the default hasher for hashmaps and hashsets from `FxHash` to `aHash` for better performance with string keys. Use `ArcSwap` instead of `RwLock` for internal ODoH config storage.
- Deps.
- Refactor: Various minor improvements.